### PR TITLE
Enable automatic retries for AWS fails, add testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ It auto-generates the:
 - Helper states which Task and Parallel States need to work properly in Socless
 - The Yaml config required to upload the State Machine to Atlas via Cloudformation
 - The Input description for the Playbook
+- Task Failure handlers for all task states that will trigger when a Lambda fails
 - Retry logic for all task states that will handle AWS Lambda service exceptions
 
 ## Usage
 
 Create your Socless Playbook Definition in a file called playbook.json.
 
-The default retry object assigned to each task looks like this:
+The default retry object assigned to each `Task` looks like this:
 
 ```json
 {
@@ -38,6 +39,21 @@ To **disable** default retries on certain tasks or all tasks, use the Decorators
 "Decorators" : {
    "DisableDefaultRetry" : {
       "all" : true
+   }
+}
+```
+
+To automatically add a Task Failure Handler to each `Task` state that will trigger when a Lambda raises an unhandled exception, timeout, out of memory, etc :
+```json
+"Decorators": {
+   "TaskFailureHandler": {
+      "Type": "Task",
+      "Resource": "${{self:custom.slack.SendMessage}}",
+      "Parameters": {
+         "message_template": "SOCless execution failure of {context.artifacts.event.event_type} was detected around {context.artifacts.event.created_at} \n\n Execution ID: {context.artifacts.execution_id} \n Investigation ID: {context.artifacts.event.investigation_id}",
+         "target": "SOCless_Failures",
+         "target_type": "channel"
+      }
    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # SLS-APB
-Serverless Plugin for Socless Playbook Builder (apb). Automatically renders State Machines from playbook.json files when a socless-playbooks stack is deployed.
+
+Serverless Plugin for SOCless Playbook Builder (apb). Automatically renders State Machines from playbook.json files when a socless-playbooks stack is deployed.
+
+It auto-generates the:
+
+- Helper states which Task and Parallel States need to work properly in Socless
+- The Yaml config required to upload the State Machine to Atlas via Cloudformation
+- The Input description for the Playbook
+- Retry logic for all task states that will handle AWS Lambda service exceptions
+
+## Usage
+
+Create your Socless Playbook Definition in a file called playbook.json.
+
+The default retry object assigned to each task looks like this:
+
+```json
+{
+  "ErrorEquals": [ "Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+  "IntervalSeconds": 2,
+  "MaxAttempts": 6,
+  "BackoffRate": 2
+}
+```
+
+To **disable** default retries on certain tasks or all tasks, use the Decorators object DisableDefaultRetry:
+
+```json
+"Decorators" : {
+   "DisableDefaultRetry" : {
+      "tasks" : [ "End_Cheer_Up", "<other_task_name>" ],
+   }
+}
+```
+
+```json
+"Decorators" : {
+   "DisableDefaultRetry" : {
+      "all" : true
+   }
+}
+```

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -4,6 +4,13 @@ let Parameters = {}
 
 //TODO: Validate that constructor input contains all the fields that are needed
 
+const RETRY = {
+  "ErrorEquals": [ "Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+  "IntervalSeconds": 2, 
+  "MaxAttempts": 6, 
+  "BackoffRate": 2 
+}
+
 class apb {
 
   constructor(definition){
@@ -82,11 +89,39 @@ class apb {
   }
 
   transformCatchConfig(catchConfig, States){
-    let catches = []
+    const catches = []
     _.forEach(catchConfig, (catchState) => {
       catches.push( Object.assign({}, catchState, { Next: this.resolveStateName(catchState.Next, States)}))
     })
     return catches
+  }
+
+ transformRetryConfig(retryConfig, stateName){
+    const retries = []
+    const currentRetry = JSON.parse(JSON.stringify(RETRY)); // deepcopy
+
+    _.forEach(retryConfig, (retryState) => {
+
+      currentRetry.ErrorEquals = currentRetry.ErrorEquals.filter(e => {
+        return !retryState.ErrorEquals.includes(e)
+      })
+      retries.push( Object.assign({}, retryState))
+    })
+
+    if ( currentRetry.ErrorEquals.length >= 1 && !this.isDefaultRetryDisabled(stateName) ){
+      retries.push(currentRetry)
+    }
+
+    return retries
+  }
+
+  isDefaultRetryDisabled(stateName){
+    if(this.Decorators.DisableDefaultRetry){
+      const disable = this.Decorators.DisableDefaultRetry
+      return disable.all || (disable.tasks && disable.tasks.includes(stateName))
+    }else{
+      return false
+    }
   }
 
   transformTaskState(stateName, stateConfig, States, DecoratorFlags){
@@ -99,6 +134,12 @@ class apb {
 
     if ( _.has(stateConfig, 'Catch') ) {
       Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States)} )
+    }
+
+    if (_.has(stateConfig, 'Retry')){
+      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName)})
+    } else if ( !this.isDefaultRetryDisabled(stateName) ){
+      Object.assign(newConfig, {"Retry": [ RETRY ] } )
     }
 
     if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,228 @@
+{
+  "name": "sls-apb",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^2.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "sls-apb",
   "version": "1.0.0",
-  "description": "Serverless plugin for socless Playbook Builder",
+  "description": "Serverless plugin for Socless Playbook Builder",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/mocha"
   },
   "keywords": [
     "socless",
@@ -16,5 +16,8 @@
   "dependencies": {
     "fs-extra": "^7.0.0",
     "lodash": "^4.17.10"
+  },
+  "devDependencies": {
+    "mocha": "^4.1.0"
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,310 @@
+const testDefinition = {
+	"Playbook": "Check_User_Happiness",
+	"Comment": "Sample Playbook to Geolocate an IP",
+	"StartAt": "Slack_User_For_Response",
+	"States": {
+		"Slack_User_For_Response": {
+			"Type": "Task",
+			"Parameters": {
+				"no_text": "No",
+				"prompt_text": "Are you happy?",
+				"receiver": "Await_User_Response",
+				"target": "$.results.Validate_Username.name",
+				"target_type": "user",
+				"text": "Hi, are you happy?",
+				"yes_text": "Yes"
+			},
+			"Catch": [
+				{
+					"ErrorEquals": ["States.ALL"],
+					"Next": "Is_User_Happy"
+				}
+			],
+			"Retry": [ 
+				{
+					"ErrorEquals": [ "ConnectionError"],
+					"IntervalSeconds": 30, 
+					"MaxAttempts": 2, 
+					"BackoffRate": 2
+				}
+			],
+			"Resource": "${{self:custom.slack.PromptForConfirmation}}",
+			"Next": "Await_User_Response"
+		},
+		"Await_User_Response": {
+			"Type": "Task",
+			"Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
+			"Retry": [ 
+				{
+					"ErrorEquals": [ "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+					"IntervalSeconds": 2, 
+					"MaxAttempts": 6, 
+					"BackoffRate": 2 
+				}
+			],
+			"Next": "Is_User_Happy"
+		},
+		"Is_User_Happy": {
+			"Type": "Choice",
+			"Choices": [
+				{
+				"Variable": "$.results.result",
+				"StringEquals": "false",
+				"Next": "User_Is_Not_Happy"
+				}
+			],
+			"Default": "User_Is_Happy"
+		},
+		"User_Is_Happy": {
+			"Type": "Pass",
+			"Next": "Celebrate_With_User"
+		},
+		"Celebrate_With_User": {
+			"Type": "Task",
+			"Parameters": {
+				"message_template": "I'm happy too! Yay!",
+				"target": "user",
+				"target_type": "channel"
+			},
+			"Resource": "${{self:custom.slack.SendMessage}}",
+			"Next": "Mark_As_Success"
+		},
+		"Mark_As_Success": {
+			"Type": "Succeed"
+		},
+		"User_Is_Not_Happy": {
+			"Type": "Pass",
+			"Next": "Parallel_Cheer_User_Up"
+		},
+		"Parallel_Cheer_User_Up": {
+			"Type": "Parallel",
+			"Next": "End_Cheer_Up",
+			"Branches": [{
+					"StartAt": "Slack_User_Happiness",
+					"States": {
+						"Slack_User_Happiness": {
+							"Type": "Task",
+							"Parameters": {
+								"message_template": "I'm happy too! Yay!",
+								"target": "user",
+								"target_type": "channel"
+							},
+							"Resource": "${{self:custom.slack.PromptForConfirmation}}",
+							"End": true
+						}
+					}
+				},
+				{
+					"StartAt": "Order_Pizza_For_User",
+					"States": {
+						"Order_Pizza_For_User": {
+							"Type": "Task",
+							"Parameters": {
+								"type": "bbq with bacon bits",
+								"restaurant": "Five10 Pizza"
+							},
+							"Resource": "${{self:custom.hubgrub.PlaceOrder}}",
+							"Next": "Pour_Coffee_For_User"
+						},
+						"Pour_Coffee_For_User": {
+							"Type": "Task",
+							"Parameters": {
+								"how": "coffee, sugar, cream"
+							},
+							"Resource": "${{self:custom.iotBrewer.PourCoffee}}",
+							"End": true
+						}
+					}
+				}
+			]
+		},
+		"End_Cheer_Up": {
+			"Type": "Task",
+			"Parameters": {
+				"status": "done"
+			},
+			"Resource": "${{self.custom.jira.TransitionIssue}}",
+			"End": true
+		}
+	},
+	"Decorators" : {
+		"DisableDefaultRetry" : {
+			"tasks" : [ "End_Cheer_Up" ],
+			"all" : false
+		}
+	}
+}
+
+
+const expectedInputJson = {
+    "artifacts": {},
+    "errors": {},
+    "parameters": {
+        "Slack_User_For_Response": {
+            "no_text": "No",
+            "prompt_text": "Are you happy?",
+            "receiver": "Await_User_Response",
+            "target": "$.results.Validate_Username.name",
+            "target_type": "user",
+            "text": "Hi, are you happy?",
+            "yes_text": "Yes"
+        },
+        "Await_User_Response": {},
+        "Celebrate_With_User": {
+            "message_template": "I'm happy too! Yay!",
+            "target": "user",
+            "target_type": "channel"
+        },
+        "Slack_User_Happiness": {
+            "message_template": "I'm happy too! Yay!",
+            "target": "user",
+            "target_type": "channel"
+        },
+        "Order_Pizza_For_User": {
+            "type": "bbq with bacon bits",
+            "restaurant": "Five10 Pizza"
+        },
+        "Pour_Coffee_For_User": {
+            "how": "coffee, sugar, cream"
+        },
+        "End_Cheer_Up": {
+            "status": "done"
+        }
+    },
+    "this": "start",
+    "results": {}
+}
+
+const expectedStateMachine = {
+    "Comment": "Sample Playbook to Geolocate an IP",
+    "StartAt": "helper_slack_user_for_response",
+    "States": {
+        "helper_slack_user_for_response": {
+            "Type": "Pass",
+            "Result": "Slack_User_For_Response",
+            "ResultPath": "$.this",
+            "Next": "Slack_User_For_Response"
+        },
+        "Slack_User_For_Response": {
+            "Type": "Task",
+            "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+            "Next": "helper_await_user_response"
+        },
+        "helper_await_user_response": {
+            "Type": "Pass",
+            "Result": "Await_User_Response",
+            "ResultPath": "$.this",
+            "Next": "Await_User_Response"
+        },
+        "Await_User_Response": {
+            "Type": "Task",
+            "Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
+            "Next": "Is_User_Happy"
+        },
+        "Is_User_Happy": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.results.result",
+                    "StringEquals": "false",
+                    "Next": "User_Is_Not_Happy"
+                }
+            ],
+            "Default": "User_Is_Happy"
+        },
+        "User_Is_Happy": {
+            "Type": "Pass",
+            "Next": "helper_celebrate_with_user"
+        },
+        "helper_celebrate_with_user": {
+            "Type": "Pass",
+            "Result": "Celebrate_With_User",
+            "ResultPath": "$.this",
+            "Next": "Celebrate_With_User"
+        },
+        "Celebrate_With_User": {
+            "Type": "Task",
+            "Resource": "${{self:custom.slack.SendMessage}}",
+            "Next": "Mark_As_Success"
+        },
+        "Mark_As_Success": {
+            "Type": "Succeed"
+        },
+        "User_Is_Not_Happy": {
+            "Type": "Pass",
+            "Next": "Parallel_Cheer_User_Up"
+        },
+        "Parallel_Cheer_User_Up": {
+            "Type": "Parallel",
+            "Next": "merge_parallel_cheer_user_up",
+            "Branches": [
+                {
+                    "StartAt": "helper_slack_user_happiness",
+                    "States": {
+                        "helper_slack_user_happiness": {
+                            "Type": "Pass",
+                            "Result": "Slack_User_Happiness",
+                            "ResultPath": "$.this",
+                            "Next": "Slack_User_Happiness"
+                        },
+                        "Slack_User_Happiness": {
+                            "Type": "Task",
+                            "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+                            "End": true
+                        }
+                    }
+                },
+                {
+                    "StartAt": "helper_order_pizza_for_user",
+                    "States": {
+                        "helper_order_pizza_for_user": {
+                            "Type": "Pass",
+                            "Result": "Order_Pizza_For_User",
+                            "ResultPath": "$.this",
+                            "Next": "Order_Pizza_For_User"
+                        },
+                        "Order_Pizza_For_User": {
+                            "Type": "Task",
+                            "Resource": "${{self:custom.hubgrub.PlaceOrder}}",
+                            "Next": "helper_pour_coffee_for_user"
+                        },
+                        "helper_pour_coffee_for_user": {
+                            "Type": "Pass",
+                            "Result": "Pour_Coffee_For_User",
+                            "ResultPath": "$.this",
+                            "Next": "Pour_Coffee_For_User"
+                        },
+                        "Pour_Coffee_For_User": {
+                            "Type": "Task",
+                            "Resource": "${{self:custom.iotBrewer.PourCoffee}}",
+                            "End": true
+                        }
+                    }
+                }
+            ]
+        },
+        "merge_parallel_cheer_user_up": {
+            "Type": "Task",
+            "Resource": "${{self:custom.core.MergeParallelOutput}}",
+            "Next": "helper_end_cheer_up"
+        },
+        "helper_end_cheer_up": {
+            "Type": "Pass",
+            "Result": "End_Cheer_Up",
+            "ResultPath": "$.this",
+            "Next": "End_Cheer_Up"
+        },
+        "End_Cheer_Up": {
+            "Type": "Task",
+            "Resource": "${{self.custom.jira.TransitionIssue}}",
+            "End": true
+        }
+    }
+}
+
+
+module.exports = {
+	definition: testDefinition,
+	Input: expectedInputJson,
+	StateMachine: expectedStateMachine
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,158 @@
+const assert = require('assert')
+const _ = require('lodash')
+const apb = require('../lib/apb.js')
+const testHelper = require('./helper.js')
+
+let {definition, Input, StateMachine} = testHelper
+let t = new apb(definition)
+
+
+const DecoratorFlags = {
+    TaskFailureHandlerName: '_Handle_Task_Failure',
+    TaskFailureHandlerStartLabel: '_Task_Failed',
+    TaskFailureHandlerEndLabel: '_End_With_Failure'
+}
+
+describe('apb', function(){
+
+  describe('#isStateIntegration', function(){
+    it('should return "true" for a top-level Task state', function(){
+      assert.equal(true, t.isStateIntegration("Slack_User_For_Response"))
+    })
+
+    it('should throw "Error" for Task state nested in Parallel state when default input is used', function(){
+      assert.throws(()=> {t.isStateIntegration("Slack_User_Happiness")}, Error)
+    })
+
+    it('should return "true" for Task state nested in Parallel state when correct branch of Parallel state is used as input',function(){
+      assert.equal(true, t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[0].States))
+    })
+
+    it('should throw "Error" for Task state nested in Parallel state when incorrect branch of Parallel state is used as input',function(){
+      assert.throws(() => {t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[1].States)},Error)
+    })
+
+    it('should throw "Error" when State does not exist in States object',function(){
+      assert.throws(() => {t.isStateIntegration("This_State_Does_Not_Exist")}, Error)
+    })
+
+    it('should return false for Await state', function(){
+      assert.equal(false, t.isStateIntegration("Await_User_Response"))
+    })
+
+    it('should return "false" for all other states states',function(){
+      let testCases = ["Is_User_Happy", "User_Is_Happy", "Mark_As_Success", "Parallel_Cheer_User_Up"] // Choice, Pass, Succeed Parallel
+      _.forEach(testCases, (state) => assert.equal(false,t.isStateIntegration(state)))
+    })
+
+  })
+
+
+  describe('#transformTaskState',function(){
+
+
+    it('should correctly generate integration task states',function(){
+      let expected = {
+        helper_slack_user_for_response: {
+          "Type": "Pass",
+          "Result": {
+            "Name": "Slack_User_For_Response",
+            "Parameters": {
+              "no_text": "No",
+              "prompt_text": "Are you happy?",
+              "receiver": "Await_User_Response",
+              "target": "$.results.Validate_Username.name",
+              "target_type": "user",
+              "text": "Hi, are you happy?",
+              "yes_text": "Yes"
+            },
+          },
+          "ResultPath": "$.State_Config",
+          "Next": "Slack_User_For_Response"
+        },
+
+        Slack_User_For_Response: {  
+          "Type": "Task",
+          "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+            "Catch": [
+              {
+                  "ErrorEquals": ["States.ALL"],
+                  "Next": "Is_User_Happy"
+              }
+            ],
+          "Retry": [ 
+            {
+              "ErrorEquals": [ "ConnectionError"],
+              "IntervalSeconds": 30, 
+              "MaxAttempts": 2, 
+              "BackoffRate": 2
+            },
+            {
+              "ErrorEquals": [ "Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+              "IntervalSeconds": 2, 
+              "MaxAttempts": 6, 
+              "BackoffRate": 2 
+            }
+          ],
+          "Next": "Await_User_Response"
+        }
+      }
+
+      assert.deepEqual(t.transformTaskState("Slack_User_For_Response",definition.States.Slack_User_For_Response,definition.States, DecoratorFlags), expected)
+    })
+
+    it('should correctly generate non-integration task states', function(){
+      let expected = {
+        Await_User_Response: {
+          "Type": "Task",
+          "Resource": "${{self:custom.core.AwaitMessageResponseActivity}}",
+          "Retry": [ 
+            {
+              "ErrorEquals": [ "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+              "IntervalSeconds": 2, 
+              "MaxAttempts": 6, 
+              "BackoffRate": 2 
+            },
+            {
+            "ErrorEquals": [ "Lambda.ServiceException"],
+            "IntervalSeconds": 2, 
+            "MaxAttempts": 6, 
+            "BackoffRate": 2 
+            }
+          ],
+          "Next": "Is_User_Happy"
+        }
+      }
+
+      assert.deepEqual(t.transformTaskState("Await_User_Response",definition.States.Await_User_Response,definition.States, DecoratorFlags), expected)
+    })
+
+
+
+    it('should not add retry logic when disabled',function(){
+      let expected = {
+        "End_Cheer_Up": {
+          "End": true,
+          "Resource": "${{self.custom.jira.TransitionIssue}}",
+          "Type": "Task",
+        },
+        "helper_end_cheer_up": {
+          "Type": "Pass",
+          "Result": {
+            "Name": "End_Cheer_Up",
+            "Parameters": {
+            "status": "done"
+            }
+          },
+          "ResultPath": "$.State_Config",
+          "Next": "End_Cheer_Up"
+        }
+      }
+
+      assert.deepEqual(t.transformTaskState("End_Cheer_Up",definition.States.End_Cheer_Up, definition.States, DecoratorFlags), expected)
+    })
+
+  })
+
+
+})


### PR DESCRIPTION
Lambdas invoked via Step Functions may sometimes fail due to various random hiccups in AWS itself. [Handling these errors](https://docs.aws.amazon.com/step-functions/latest/dg/bp-lambda-serviceexception.html) involves adding a "Retry" block on each Lambda "Task" state that will trigger on the 3 common AWS service exception errors. 

This PR enables `sls-apb` to automatically put these retries on every Task, so that you can keep your playbooks.json (relatively) short and sweet. 
It also allows you to customize this functionality by using a Decorator at the end of playbooks.json. With the decorator you can disable default retries for specific States passed in via a list of State Names, or simply disable default retries on all tasks.

```json
"Decorators" : {
   "DisableDefaultRetry" : {
      "tasks" : [ "End_Cheer_Up", "<other_task_name>" ],
   }
}
```
```json
"Decorators" : {
   "DisableDefaultRetry" : {
      "all" : true
   }
}
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
