### PR TITLE
Add interaction state type

### DIFF
--- a/lib/apb.js
+++ b/lib/apb.js
@@ -27,11 +27,25 @@ class apb {
     if (States[stateName] === undefined) {
       throw new Error(`State ${stateName} does not exist in the States object`)
     }
-    return States[stateName].Type === "Task" && _.has(States[stateName], 'Parameters')
+    return (States[stateName].Type === "Task" || States[stateName].Type === "Interaction" ) && _.has(States[stateName], 'Parameters')
   }
 
   genIntegrationHelperStateName(originalName){
-    return `helper_${originalName.toLowerCase()}`.slice(0,128)
+    return `helper_${originalName.toLowerCase()}`.slice(0 128)
+  }
+
+  genHelperState(stateConfig, stateName){
+    let helperState = {
+      Type: "Pass",
+      Result: {
+        "Name": stateName,
+        "Parameters": stateConfig.Parameters
+      },
+      ResultPath: "$.State_Config",
+      Next: stateName
+    }
+
+    return helperState
   }
 
   resolveStateName(stateName, States = this.States ){
@@ -96,7 +110,7 @@ class apb {
     return catches
   }
 
- transformRetryConfig(retryConfig, stateName){
+  transformRetryConfig(retryConfig, stateName){
     const retries = []
     const currentRetry = JSON.parse(JSON.stringify(RETRY)); // deepcopy
 
@@ -150,23 +164,62 @@ class apb {
 
     if (this.isStateIntegration(stateName, States)){
       // Generate helper state
+      const helperState = this.genHelperState(stateConfig, stateName)
       let helperStateName = this.genIntegrationHelperStateName(stateName)
-      let helperState = {
-        Type: "Pass",
-        Result: {
-          "Name": stateName,
-          "Parameters": stateConfig.Parameters
-        },
-        ResultPath: "$.State_Config",
-        Next: stateName
-      }
       Object.assign(output, {[helperStateName]: helperState})
     }
+
     delete newConfig['Parameters']
     Object.assign(output,{[stateName]: newConfig})
     return output
   }
 
+  transformInteractionState(stateName, stateConfig, States, DecoratorFlags){
+
+    let output = {}
+    let newConfig = Object.assign({}, stateConfig)
+
+    if ( _.has(stateConfig, 'Next') ) {
+      Object.assign(newConfig, { Next: this.resolveStateName(stateConfig.Next, States)})
+    }
+
+    if ( _.has(stateConfig, 'Catch') ) {
+      Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States)} )
+    }
+
+    if (_.has(stateConfig, 'Retry')){
+      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName)})
+    } else if ( !this.isDefaultRetryDisabled(stateName) ){
+      Object.assign(newConfig, {"Retry": [ RETRY ] } )
+    }
+
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName){
+      let currentCatchConfig = newConfig.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
+
+    if (this.isStateIntegration(stateName, States)){
+      // Generate helper state and set Invoke lambda resource
+      const helperState = this.genHelperState(stateConfig, stateName)
+      let helperStateName = this.genIntegrationHelperStateName(stateName)
+      Object.assign(output, {[helperStateName]: helperState})
+    }
+
+    // Convert Interaction to Task
+    newConfig.Parameters = {
+      FunctionName : newConfig.Resource,
+      Payload : {
+        "sfn_context.$" : "$",
+        "task_token.$" : "$$.Task.Token"
+      }
+    }
+    newConfig.Resource = "arn:aws:states:::lambda:invoke.waitForTaskToken"
+    newConfig.Type = "Task"
+
+    Object.assign(output,{[stateName]: newConfig})
+    return output
+  }
 
   transformParallelState(stateName, stateConfig, States, DecoratorFlags) {
     let Output = {}
@@ -176,17 +229,17 @@ class apb {
       Type: "Task",
       Resource: "${{self:custom.core.MergeParallelOutput}}"
     }
-     if ( End === undefined ){
-       Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States)})
-     } else {
-       Object.assign(helperState, { End: true })
-     }
+    if ( End === undefined ){
+      Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States)})
+    } else {
+      Object.assign(helperState, { End: true })
+    }
 
-     if (DecoratorFlags.hasTaskFailureHandler === true ){
-       let currentCatchConfig = topLevel.Catch || []
-       let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
-       topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
-     }
+    if (DecoratorFlags.hasTaskFailureHandler === true ){
+      let currentCatchConfig = topLevel.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
 
     let newBranches = []
     Object.assign(Output, topLevel, { Next: helperStateName } )
@@ -235,6 +288,8 @@ class apb {
         Object.assign(output, this.transformSuccessFailState(stateName, stateConfig, States))
       } else if (stateConfig.Type === "Task") {
         Object.assign(output, this.transformTaskState(stateName, stateConfig, States, DecoratorFlags))
+      } else if (stateConfig.Type === "Interaction") {
+        Object.assign(output, this.transformInteractionState(stateName, stateConfig, States, DecoratorFlags))
       } else if (stateConfig.Type === "Parallel") {
         Object.assign(output, this.transformParallelState(stateName, stateConfig, States, DecoratorFlags))
       }

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -31,7 +31,7 @@ class apb {
   }
 
   genIntegrationHelperStateName(originalName){
-    return `helper_${originalName.toLowerCase()}`.slice(0 128)
+    return `helper_${originalName.toLowerCase()}`.slice(0, 128)
   }
 
   genHelperState(stateConfig, stateName){
@@ -56,7 +56,7 @@ class apb {
     }
   }
 
-  transformChoiceState(stateName,stateConfig, States = this.States){
+  transformChoiceState(stateName, stateConfig, States = this.States){
     let choices = []
     _.forEach(stateConfig.Choices, (choice) => {
       choices.push( Object.assign({}, choice, {Next: this.resolveStateName(choice.Next, States)}))
@@ -170,7 +170,7 @@ class apb {
     }
 
     delete newConfig['Parameters']
-    Object.assign(output,{[stateName]: newConfig})
+    Object.assign(output, {[stateName]: newConfig})
     return output
   }
 
@@ -217,14 +217,14 @@ class apb {
     newConfig.Resource = "arn:aws:states:::lambda:invoke.waitForTaskToken"
     newConfig.Type = "Task"
 
-    Object.assign(output,{[stateName]: newConfig})
+    Object.assign(output, {[stateName]: newConfig})
     return output
   }
 
   transformParallelState(stateName, stateConfig, States, DecoratorFlags) {
     let Output = {}
     let {Branches, End, ...topLevel}  = stateConfig
-    let helperStateName = `merge_${stateName.toLowerCase()}`.slice(0,128)
+    let helperStateName = `merge_${stateName.toLowerCase()}`.slice(0, 128)
     let helperState = {
       Type: "Task",
       Resource: "${{self:custom.core.MergeParallelOutput}}"
@@ -298,7 +298,7 @@ class apb {
   }
 
   validateDefinition(definition){
-    const REQUIRED_FIELDS = ['Playbook', 'Comment', 'StartAt','States']
+    const REQUIRED_FIELDS = ['Playbook', 'Comment', 'StartAt', 'States']
     let keys = Object.keys(definition)
     _.forEach(REQUIRED_FIELDS, (key) => {
       if (!keys.includes(key)){
@@ -378,7 +378,7 @@ class apb {
             RoleArn: "${{self:custom.statesRole}}",
             StateMachineName: this.PlaybookName,
             DefinitionString: {
-              "Fn::Sub": JSON.stringify(this.StateMachine,null,4)
+              "Fn::Sub": JSON.stringify(this.StateMachine, null, 4)
             }
           }
         }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,22 @@
 const testDefinition = {
 	"Playbook": "Check_User_Happiness",
 	"Comment": "Sample Playbook to Geolocate an IP",
-	"StartAt": "Slack_User_For_Response",
+	"StartAt": "New_Interaction_State",
 	"States": {
+        "New_Interaction_State": {
+            "Type": "Interaction",
+            "Resource": "${{self:custom.slack.PromptForConfirmation}}",
+            "Parameters": {
+                "no_text": "No",
+                "prompt_text": "Are you happy?",
+                "receiver": "Slack_User_For_Response",
+                "target": "$.results.Validate_Username.name",
+                "target_type": "user",
+                "text": "Hi, are you happy?",
+                "yes_text": "Yes"
+            },
+            "Next": "Slack_User_For_Response",
+        },
 		"Slack_User_For_Response": {
 			"Type": "Task",
 			"Parameters": {

--- a/test/test.js
+++ b/test/test.js
@@ -13,34 +13,34 @@ const DecoratorFlags = {
     TaskFailureHandlerEndLabel: '_End_With_Failure'
 }
 
-describe('apb', function(){
+describe('apb', () => {
 
-  describe('#isStateIntegration', function(){
-    it('should return "true" for a top-level Task state', function(){
+  describe('#isStateIntegration', () => {
+    it('should return "true" for a top-level Task state', () => {
       assert.equal(true, t.isStateIntegration("Slack_User_For_Response"))
     })
 
-    it('should throw "Error" for Task state nested in Parallel state when default input is used', function(){
+    it('should throw "Error" for Task state nested in Parallel state when default input is used', () => {
       assert.throws(()=> {t.isStateIntegration("Slack_User_Happiness")}, Error)
     })
 
-    it('should return "true" for Task state nested in Parallel state when correct branch of Parallel state is used as input',function(){
+    it('should return "true" for Task state nested in Parallel state when correct branch of Parallel state is used as input', () => {
       assert.equal(true, t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[0].States))
     })
 
-    it('should throw "Error" for Task state nested in Parallel state when incorrect branch of Parallel state is used as input',function(){
+    it('should throw "Error" for Task state nested in Parallel state when incorrect branch of Parallel state is used as input', () => {
       assert.throws(() => {t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[1].States)},Error)
     })
 
-    it('should throw "Error" when State does not exist in States object',function(){
+    it('should throw "Error" when State does not exist in States object', () => {
       assert.throws(() => {t.isStateIntegration("This_State_Does_Not_Exist")}, Error)
     })
 
-    it('should return false for Await state', function(){
+    it('should return false for Await state', () => {
       assert.equal(false, t.isStateIntegration("Await_User_Response"))
     })
 
-    it('should return "false" for all other states states',function(){
+    it('should return "false" for all other states states', () => {
       let testCases = ["Is_User_Happy", "User_Is_Happy", "Mark_As_Success", "Parallel_Cheer_User_Up"] // Choice, Pass, Succeed Parallel
       _.forEach(testCases, (state) => assert.equal(false,t.isStateIntegration(state)))
     })
@@ -48,10 +48,9 @@ describe('apb', function(){
   })
 
 
-  describe('#transformTaskState',function(){
+  describe('#transformTaskState', () => {
 
-
-    it('should correctly generate integration task states',function(){
+    it('should correctly generate integration task states', () => {
       let expected = {
         helper_slack_user_for_response: {
           "Type": "Pass",
@@ -101,7 +100,7 @@ describe('apb', function(){
       assert.deepEqual(t.transformTaskState("Slack_User_For_Response",definition.States.Slack_User_For_Response,definition.States, DecoratorFlags), expected)
     })
 
-    it('should correctly generate non-integration task states', function(){
+    it('should correctly generate non-integration task states', () => {
       let expected = {
         Await_User_Response: {
           "Type": "Task",
@@ -128,8 +127,7 @@ describe('apb', function(){
     })
 
 
-
-    it('should not add retry logic when disabled',function(){
+    it('should not add retry logic when disabled', () => {
       let expected = {
         "End_Cheer_Up": {
           "End": true,
@@ -154,5 +152,60 @@ describe('apb', function(){
 
   })
 
+  describe('#transformInteractionState', () => {
+    it('should correctly generate an Interaction task state', () =>  {
+      let expected = {
+        helper_new_interaction_state: {
+          "Type": "Pass",
+          "Result": {
+            "Name": "New_Interaction_State",
+            "Parameters": {
+              "no_text": "No",
+              "prompt_text": "Are you happy?",
+              "receiver": "Slack_User_For_Response",
+              "target": "$.results.Validate_Username.name",
+              "target_type": "user",
+              "text": "Hi, are you happy?",
+              "yes_text": "Yes"
+            },
+          },
+          "ResultPath": "$.State_Config",
+          "Next": "New_Interaction_State"
+        },
+        New_Interaction_State: {
+          "Type": "Task",
+          "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+          "Parameters": {
+            "FunctionName": "${{self:custom.slack.PromptForConfirmation}}",
+            "Payload": {
+              "sfn_context.$": "$",
+              "task_token.$": "$$.Task.Token"
+            }
+          },
+          "Retry": [
+            {
+              "BackoffRate": 2,
+              "ErrorEquals": [
+                "Lambda.ServiceException",
+                "Lambda.AWSLambdaException",
+                "Lambda.SdkClientException",
+              ],
+              "IntervalSeconds": 2,
+              "MaxAttempts": 6,
+            }
+          ],
+          "Next": "helper_slack_user_for_response"
+        }
+      }
+
+      assert.deepEqual(t.transformInteractionState(
+          "New_Interaction_State",
+          definition.States.New_Interaction_State,
+          definition.States,
+          DecoratorFlags
+          ), expected)
+    })
+
+  })
 
 })

--- a/test/test.js
+++ b/test/test.js
@@ -25,11 +25,11 @@ describe('apb', () => {
     })
 
     it('should return "true" for Task state nested in Parallel state when correct branch of Parallel state is used as input', () => {
-      assert.equal(true, t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[0].States))
+      assert.equal(true, t.isStateIntegration("Slack_User_Happiness", definition.States.Parallel_Cheer_User_Up.Branches[0].States))
     })
 
     it('should throw "Error" for Task state nested in Parallel state when incorrect branch of Parallel state is used as input', () => {
-      assert.throws(() => {t.isStateIntegration("Slack_User_Happiness",definition.States.Parallel_Cheer_User_Up.Branches[1].States)},Error)
+      assert.throws(() => {t.isStateIntegration("Slack_User_Happiness", definition.States.Parallel_Cheer_User_Up.Branches[1].States)}, Error)
     })
 
     it('should throw "Error" when State does not exist in States object', () => {
@@ -42,7 +42,7 @@ describe('apb', () => {
 
     it('should return "false" for all other states states', () => {
       let testCases = ["Is_User_Happy", "User_Is_Happy", "Mark_As_Success", "Parallel_Cheer_User_Up"] // Choice, Pass, Succeed Parallel
-      _.forEach(testCases, (state) => assert.equal(false,t.isStateIntegration(state)))
+      _.forEach(testCases, (state) => assert.equal(false, t.isStateIntegration(state)))
     })
 
   })
@@ -97,7 +97,7 @@ describe('apb', () => {
         }
       }
 
-      assert.deepEqual(t.transformTaskState("Slack_User_For_Response",definition.States.Slack_User_For_Response,definition.States, DecoratorFlags), expected)
+      assert.deepEqual(t.transformTaskState("Slack_User_For_Response", definition.States.Slack_User_For_Response, definition.States, DecoratorFlags), expected)
     })
 
     it('should correctly generate non-integration task states', () => {
@@ -123,7 +123,7 @@ describe('apb', () => {
         }
       }
 
-      assert.deepEqual(t.transformTaskState("Await_User_Response",definition.States.Await_User_Response,definition.States, DecoratorFlags), expected)
+      assert.deepEqual(t.transformTaskState("Await_User_Response", definition.States.Await_User_Response, definition.States, DecoratorFlags), expected)
     })
 
 
@@ -147,7 +147,7 @@ describe('apb', () => {
         }
       }
 
-      assert.deepEqual(t.transformTaskState("End_Cheer_Up",definition.States.End_Cheer_Up, definition.States, DecoratorFlags), expected)
+      assert.deepEqual(t.transformTaskState("End_Cheer_Up", definition.States.End_Cheer_Up, definition.States, DecoratorFlags), expected)
     })
 
   })


### PR DESCRIPTION
In the words of @ubaniabalogun : 

Currently, Human Interaction Workflows are configured using two Task states: one that uses a Lambda function to start a human interaction, and another that uses the AwaitMessageResponseActivity to receive the human’s response and end the interaction.

In the proposed solution, only one Task state will be needed to configure a human interaction. This Task state will be configured using AWS Step Functions’ [Wait For Callback](https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html) Pattern, which differs from the stock Task state configuration playbook authors are used to. As such, to simplify configuration for users, an ‘Interaction’ State Type that has an interface consistent with what playbook authors are used to is proposed. Sls-apb will interpret the `Interaction` State type and transform it to an appropriately configured Wait For Callback Task state. 

Specifically, an author will configure a human interaction state in a playbook as:
```
“Request_Info”: {
	“Type”: “Interaction”,
	“Resource”: “${{self:custom.product.integration}}”,
	“Parameters”: {...},
	“Next”: “Next_State”
}
```
And sls-apb will convert the state to the Wait For Callback configuration below:
```
“helper_request_info”: {
	“Type”: “Pass”,
	“Result”: {
		“Name”: Request_Info”,
		“Parameters”: {....}
}
},
“Request_Info”: {
	“Type”: “Task”,
	“Resource”: “arn:aws:states:::lambda:invoke.waitForTaskToken”,
	“Parameters”: {
		“FunctionName”: “${{self:custom.product.integration}}”,
		“Payload”: {
			"sfn_context.$": "$",
			“task_token.$”: “$$.Task.Token”
}
}
}
```

The configured state will invoke the lambda called integration_name and pass the TaskToken to the lambda function in the event 

The implementation will be included in sls-apb as a function called transformInteractionState located here

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
