### PR TITLE
allow plugin to be used as a passthrough for apb

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,40 +5,51 @@ const _ = require('lodash');
 const apb = require('./lib/apb');
 
 class SlsApb {
-  constructor(serverless, options) {
-    this.sls = serverless;
+  // This module can be used as a serverless plugin or as a passthrough to apb().
+  // If serverless is not calling the constructor, SlsApb will return 
+  // a new apb(playbook_object) for other use cases (visualizations, etc.)
+  constructor(sls_or_playbook_obj, options = {}) {
+    this.sls = sls_or_playbook_obj;
     this.options = options;
 
-    let playbooks = this.sls.service.custom.playbooks
+    if(this.sls.service){
+      // SlsApb is being called as a serverless plugin
+      let playbooks = this.sls.service.custom.playbooks
 
-    if (!playbooks) {
-      this.sls.cli.log('Warning: No playbooks listed for deployment. List playbooks under `customs.playbooks` section to deploy them')
-    } else {
+      if (!playbooks) {
+        this.sls.cli.log('Warning: No playbooks listed for deployment. List playbooks under `customs.playbooks` section to deploy them')
+      } else {
 
-      if (this.sls.service.resources === undefined) {
-        this.sls.service.resources = []
-      }
-
-      _.forEach(playbooks, (playbook_dir) => {
-        // Create the path to the playbook.json file
-        let playbook_path = `./playbooks/${playbook_dir}/playbook.json`
-        this.sls.cli.log(`Rendering State Machine for ${playbook_path}...`)
-
-        // Read playbook.json file, use APB to render the State Machine then add it to the resources list
-        try {
-          let stateMachine = fse.readJsonSync(playbook_path)
-          let renderedPlaybook = new apb(stateMachine)
-          // Add the rendered State Machine to the resources list
-          this.sls.service.resources.push(renderedPlaybook.StateMachineYaml)
-        } catch (err) {
-          throw new Error(`Failed to render State Machine for ${playbook_path}: ${err.message}`)
+        if (this.sls.service.resources === undefined) {
+          this.sls.service.resources = []
         }
 
-      })
+        _.forEach(playbooks, (playbook_dir) => {
+          // Create the path to the playbook.json file
+          let playbook_path = `./playbooks/${playbook_dir}/playbook.json`
+          this.sls.cli.log(`Rendering State Machine for ${playbook_path}...`)
 
+          // Read playbook.json file, use APB to render the State Machine then add it to the resources list
+          try {
+            let stateMachine = fse.readJsonSync(playbook_path)
+            let renderedPlaybook = new apb(stateMachine)
+            // Add the rendered State Machine to the resources list
+            this.sls.service.resources.push(renderedPlaybook.StateMachineYaml)
+          } catch (err) {
+            throw new Error(`Failed to render State Machine for ${playbook_path}: ${err.message}`)
+          }
+        })
+      }
     }
+    else{
+      // SlsApb is being called as a passthrough for apb
+      return new apb(sls_or_playbook_obj)
+    }
+
+    
   }
 
 }
 
 module.exports = SlsApb;
+


### PR DESCRIPTION
In order for `sls-apb` to work as a serverless plugin, it needs to be the default export for serverless to call it with its constructor. 
The `apb` class contained in this repo is the core functionality that translates SOCless playbooks into AWS' cloudformation templates. This class can be extremely useful for non-plugin use cases such as visualizing a full SOCless playbook UI or a visualizer that can sit side-by-side your IDE.

For this to work as a plugin AND as a passthrough for `apb`, I have added a check to see if SlsApb is called from serverless, and if not it expects that its arg is a SOCless playbook object and returns `apb(playbook_obj)`

This has been tested and does not affect its serverless-plugin functionality.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
