### PR TITLE
fix TaskFailureHandler decorator's handling of parallel states

### DIFF
--- a/lib/apb.js
+++ b/lib/apb.js
@@ -139,7 +139,7 @@ class apb {
   }
 
   addTaskFailureCatchIfNeeded(stepName, stepConfig, DecoratorFlags) {
-    newStepConfig = Object.assign({}, stepConfig)
+    const newStepConfig = Object.assign({}, stepConfig)
 
     if (DecoratorFlags.hasTaskFailureHandler === true && stepName !== this.DecoratorFlags.TaskFailureHandlerName) {
       let currentCatchConfig = newStepConfig.Catch || []
@@ -167,7 +167,7 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    newConfig = addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
+    newConfig = this.addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state
@@ -200,7 +200,7 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    newConfig = addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
+    newConfig = this.addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state and set Invoke lambda resource
@@ -238,7 +238,7 @@ class apb {
       Object.assign(helperState, { End: true })
     }
 
-    topLevel = addTaskFailureCatchIfNeeded(stateName, topLevel, DecoratorFlags)
+    topLevel = this.addTaskFailureCatchIfNeeded(stateName, topLevel, DecoratorFlags)
 
     let newBranches = []
     Object.assign(Output, topLevel, { Next: helperStateName })

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -5,15 +5,15 @@ let Parameters = {}
 //TODO: Validate that constructor input contains all the fields that are needed
 
 const RETRY = {
-  "ErrorEquals": [ "Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
-  "IntervalSeconds": 2, 
-  "MaxAttempts": 6, 
-  "BackoffRate": 2 
+  "ErrorEquals": ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+  "IntervalSeconds": 2,
+  "MaxAttempts": 6,
+  "BackoffRate": 2
 }
 
 class apb {
 
-  constructor(definition){
+  constructor(definition) {
     this.DecoratorFlags = {
       TaskFailureHandlerName: '_Handle_Task_Failure',
       TaskFailureHandlerStartLabel: '_Task_Failed',
@@ -23,18 +23,18 @@ class apb {
 
   }
 
-  isStateIntegration(stateName, States = this.States){
+  isStateIntegration(stateName, States = this.States) {
     if (States[stateName] === undefined) {
       throw new Error(`State ${stateName} does not exist in the States object`)
     }
-    return (States[stateName].Type === "Task" || States[stateName].Type === "Interaction" ) && _.has(States[stateName], 'Parameters')
+    return (States[stateName].Type === "Task" || States[stateName].Type === "Interaction") && _.has(States[stateName], 'Parameters')
   }
 
-  genIntegrationHelperStateName(originalName){
+  genIntegrationHelperStateName(originalName) {
     return `helper_${originalName.toLowerCase()}`.slice(0, 128)
   }
 
-  genHelperState(stateConfig, stateName){
+  genHelperState(stateConfig, stateName) {
     let helperState = {
       Type: "Pass",
       Result: {
@@ -48,28 +48,28 @@ class apb {
     return helperState
   }
 
-  resolveStateName(stateName, States = this.States ){
-    if ( this.isStateIntegration(stateName, States) ){
+  resolveStateName(stateName, States = this.States) {
+    if (this.isStateIntegration(stateName, States)) {
       return this.genIntegrationHelperStateName(stateName)
-    } else{
+    } else {
       return stateName
     }
   }
 
-  transformChoiceState(stateName, stateConfig, States = this.States){
+  transformChoiceState(stateName, stateConfig, States = this.States) {
     let choices = []
     _.forEach(stateConfig.Choices, (choice) => {
-      choices.push( Object.assign({}, choice, {Next: this.resolveStateName(choice.Next, States)}))
+      choices.push(Object.assign({}, choice, { Next: this.resolveStateName(choice.Next, States) }))
     })
     return {
-      [stateName]: Object.assign( {}, stateConfig, {Choices: choices})
+      [stateName]: Object.assign({}, stateConfig, { Choices: choices })
     }
   }
 
-  transformPassState(stateName, stateConfig, States = this.States){
-    if (_.has(stateConfig, 'Next') ) {
+  transformPassState(stateName, stateConfig, States = this.States) {
+    if (_.has(stateConfig, 'Next')) {
       return {
-        [stateName]: Object.assign({}, stateConfig, {Next: this.resolveStateName(stateConfig.Next, States)})
+        [stateName]: Object.assign({}, stateConfig, { Next: this.resolveStateName(stateConfig.Next, States) })
       }
     } else {
       return {
@@ -78,10 +78,10 @@ class apb {
     }
   }
 
-  transformWaitState(stateName, stateConfig, States){
-    if ( _.has(stateConfig, 'Next') ) {
+  transformWaitState(stateName, stateConfig, States) {
+    if (_.has(stateConfig, 'Next')) {
       return {
-        [stateName]: Object.assign({}, stateConfig, {Next: this.resolveStateName(stateConfig.Next, States)})
+        [stateName]: Object.assign({}, stateConfig, { Next: this.resolveStateName(stateConfig.Next, States) })
       }
     } else {
       return {
@@ -91,9 +91,9 @@ class apb {
   }
 
   transformSuccessFailState(stateName, stateConfig, States) {
-    if ( _.has(stateConfig, 'Next') ) {
+    if (_.has(stateConfig, 'Next')) {
       return {
-        [stateName]: Object.assign({}, stateConfig, {Next: this.resolveStateName(stateConfig.Next, States)})
+        [stateName]: Object.assign({}, stateConfig, { Next: this.resolveStateName(stateConfig.Next, States) })
       }
     } else {
       return {
@@ -102,15 +102,15 @@ class apb {
     }
   }
 
-  transformCatchConfig(catchConfig, States){
+  transformCatchConfig(catchConfig, States) {
     const catches = []
     _.forEach(catchConfig, (catchState) => {
-      catches.push( Object.assign({}, catchState, { Next: this.resolveStateName(catchState.Next, States)}))
+      catches.push(Object.assign({}, catchState, { Next: this.resolveStateName(catchState.Next, States) }))
     })
     return catches
   }
 
-  transformRetryConfig(retryConfig, stateName){
+  transformRetryConfig(retryConfig, stateName) {
     const retries = []
     const currentRetry = JSON.parse(JSON.stringify(RETRY)); // deepcopy
 
@@ -119,130 +119,130 @@ class apb {
       currentRetry.ErrorEquals = currentRetry.ErrorEquals.filter(e => {
         return !retryState.ErrorEquals.includes(e)
       })
-      retries.push( Object.assign({}, retryState))
+      retries.push(Object.assign({}, retryState))
     })
 
-    if ( currentRetry.ErrorEquals.length >= 1 && !this.isDefaultRetryDisabled(stateName) ){
+    if (currentRetry.ErrorEquals.length >= 1 && !this.isDefaultRetryDisabled(stateName)) {
       retries.push(currentRetry)
     }
 
     return retries
   }
 
-  isDefaultRetryDisabled(stateName){
-    if(this.Decorators.DisableDefaultRetry){
+  isDefaultRetryDisabled(stateName) {
+    if (this.Decorators.DisableDefaultRetry) {
       const disable = this.Decorators.DisableDefaultRetry
       return disable.all || (disable.tasks && disable.tasks.includes(stateName))
-    }else{
+    } else {
       return false
     }
   }
 
-  transformTaskState(stateName, stateConfig, States, DecoratorFlags){
+  transformTaskState(stateName, stateConfig, States, DecoratorFlags) {
 
     let output = {}
     let newConfig = Object.assign({}, stateConfig)
-    if ( _.has(stateConfig, 'Next') ) {
-      Object.assign(newConfig, { Next: this.resolveStateName(stateConfig.Next, States)})
+    if (_.has(stateConfig, 'Next')) {
+      Object.assign(newConfig, { Next: this.resolveStateName(stateConfig.Next, States) })
     }
 
-    if ( _.has(stateConfig, 'Catch') ) {
-      Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States)} )
+    if (_.has(stateConfig, 'Catch')) {
+      Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States) })
     }
 
-    if (_.has(stateConfig, 'Retry')){
-      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName)})
-    } else if ( !this.isDefaultRetryDisabled(stateName) ){
-      Object.assign(newConfig, {"Retry": [ RETRY ] } )
+    if (_.has(stateConfig, 'Retry')) {
+      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName) })
+    } else if (!this.isDefaultRetryDisabled(stateName)) {
+      Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName){
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
       let currentCatchConfig = newConfig.Catch || []
       let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
       newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
     }
 
-    if (this.isStateIntegration(stateName, States)){
+    if (this.isStateIntegration(stateName, States)) {
       // Generate helper state
       const helperState = this.genHelperState(stateConfig, stateName)
       let helperStateName = this.genIntegrationHelperStateName(stateName)
-      Object.assign(output, {[helperStateName]: helperState})
+      Object.assign(output, { [helperStateName]: helperState })
     }
 
     delete newConfig['Parameters']
-    Object.assign(output, {[stateName]: newConfig})
+    Object.assign(output, { [stateName]: newConfig })
     return output
   }
 
-  transformInteractionState(stateName, stateConfig, States, DecoratorFlags){
+  transformInteractionState(stateName, stateConfig, States, DecoratorFlags) {
 
     let output = {}
     let newConfig = Object.assign({}, stateConfig)
 
-    if ( _.has(stateConfig, 'Next') ) {
-      Object.assign(newConfig, { Next: this.resolveStateName(stateConfig.Next, States)})
+    if (_.has(stateConfig, 'Next')) {
+      Object.assign(newConfig, { Next: this.resolveStateName(stateConfig.Next, States) })
     }
 
-    if ( _.has(stateConfig, 'Catch') ) {
-      Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States)} )
+    if (_.has(stateConfig, 'Catch')) {
+      Object.assign(newConfig, { Catch: this.transformCatchConfig(stateConfig.Catch, States) })
     }
 
-    if (_.has(stateConfig, 'Retry')){
-      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName)})
-    } else if ( !this.isDefaultRetryDisabled(stateName) ){
-      Object.assign(newConfig, {"Retry": [ RETRY ] } )
+    if (_.has(stateConfig, 'Retry')) {
+      Object.assign(newConfig, { Retry: this.transformRetryConfig(stateConfig.Retry, stateName) })
+    } else if (!this.isDefaultRetryDisabled(stateName)) {
+      Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName){
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
       let currentCatchConfig = newConfig.Catch || []
       let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
       newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
     }
 
-    if (this.isStateIntegration(stateName, States)){
+    if (this.isStateIntegration(stateName, States)) {
       // Generate helper state and set Invoke lambda resource
       const helperState = this.genHelperState(stateConfig, stateName)
       let helperStateName = this.genIntegrationHelperStateName(stateName)
-      Object.assign(output, {[helperStateName]: helperState})
+      Object.assign(output, { [helperStateName]: helperState })
     }
 
     // Convert Interaction to Task
     newConfig.Parameters = {
-      FunctionName : newConfig.Resource,
-      Payload : {
-        "sfn_context.$" : "$",
-        "task_token.$" : "$$.Task.Token"
+      FunctionName: newConfig.Resource,
+      Payload: {
+        "sfn_context.$": "$",
+        "task_token.$": "$$.Task.Token"
       }
     }
     newConfig.Resource = "arn:aws:states:::lambda:invoke.waitForTaskToken"
     newConfig.Type = "Task"
 
-    Object.assign(output, {[stateName]: newConfig})
+    Object.assign(output, { [stateName]: newConfig })
     return output
   }
 
   transformParallelState(stateName, stateConfig, States, DecoratorFlags) {
     let Output = {}
-    let {Branches, End, ...topLevel}  = stateConfig
+    let { Branches, End, ...topLevel } = stateConfig
     let helperStateName = `merge_${stateName.toLowerCase()}`.slice(0, 128)
     let helperState = {
       Type: "Task",
       Resource: "${{self:custom.core.MergeParallelOutput}}"
     }
-    if ( End === undefined ){
-      Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States)})
+    if (End === undefined) {
+      Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States) })
     } else {
       Object.assign(helperState, { End: true })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true ){
+    if (DecoratorFlags.hasTaskFailureHandler === true) {
       let currentCatchConfig = topLevel.Catch || []
       let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
       topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
     }
 
     let newBranches = []
-    Object.assign(Output, topLevel, { Next: helperStateName } )
+    Object.assign(Output, topLevel, { Next: helperStateName })
     _.forEach(Branches, (branch) => {
       newBranches.push(
         {
@@ -259,23 +259,23 @@ class apb {
     }
   }
 
-  validateTaskFailureHandlerDecorator(config){
-    if (config.Type === "Task" || config.Type === "Parallel"){
+  validateTaskFailureHandlerDecorator(config) {
+    if (config.Type === "Task" || config.Type === "Parallel") {
       return true
     } else {
       throw new Error("Decorator.TaskFailureHandler configured incorrectly. Must be a Task or Parallel state")
     }
   }
 
-  genTaskFailureHandlerCatchConfig(stateName){
+  genTaskFailureHandlerCatchConfig(stateName) {
     return {
       "ErrorEquals": ["States.TaskFailed"],
       "ResultPath": `$.errors.${stateName}`,
       "Next": this.DecoratorFlags.TaskFailureHandlerStartLabel
-      }
+    }
   }
 
-  transformStates(States = this.States, DecoratorFlags = this.DecoratorFlags ){
+  transformStates(States = this.States, DecoratorFlags = this.DecoratorFlags) {
     let output = {}
     _.forOwn(States, (stateConfig, stateName, States) => {
       if (stateConfig.Type === "Choice") {
@@ -284,7 +284,7 @@ class apb {
         Object.assign(output, this.transformPassState(stateName, stateConfig, States))
       } else if (stateConfig.Type === "Wait") {
         Object.assign(output, this.transformWaitState(stateName, stateConfig, States))
-      } else if (stateConfig.Type === "Succeed" || stateConfig.Type === "Fail" ) {
+      } else if (stateConfig.Type === "Succeed" || stateConfig.Type === "Fail") {
         Object.assign(output, this.transformSuccessFailState(stateName, stateConfig, States))
       } else if (stateConfig.Type === "Task") {
         Object.assign(output, this.transformTaskState(stateName, stateConfig, States, DecoratorFlags))
@@ -297,21 +297,21 @@ class apb {
     return output
   }
 
-  validateDefinition(definition){
+  validateDefinition(definition) {
     const REQUIRED_FIELDS = ['Playbook', 'Comment', 'StartAt', 'States']
     let keys = Object.keys(definition)
     _.forEach(REQUIRED_FIELDS, (key) => {
-      if (!keys.includes(key)){
+      if (!keys.includes(key)) {
         throw new Error(`Playbook definition does not have the required top-level key, '${key}'`)
       }
     })
   }
 
-  taskErrorHandlerExists(){
+  taskErrorHandlerExists() {
     return this.Decorators.TaskFailureHandler && this.validateTaskFailureHandlerDecorator(this.Decorators.TaskFailureHandler)
   }
 
-  genTaskFailureHandlerStates(TaskFailureHandler){
+  genTaskFailureHandlerStates(TaskFailureHandler) {
     delete TaskFailureHandler.End
     TaskFailureHandler.Next = this.DecoratorFlags.TaskFailureHandlerEndLabel
 

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -138,19 +138,7 @@ class apb {
     }
   }
 
-  addTaskFailureCatchIfNeeded(stepName, stepConfig, DecoratorFlags) {
-    const newStepConfig = Object.assign({}, stepConfig)
-
-    if (DecoratorFlags.hasTaskFailureHandler === true && stepName !== this.DecoratorFlags.TaskFailureHandlerName) {
-      let currentCatchConfig = newStepConfig.Catch || []
-      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stepName)]
-      newStepConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
-    }
-    return newStepConfig
-  }
-
   transformTaskState(stateName, stateConfig, States, DecoratorFlags) {
-
     let output = {}
     let newConfig = Object.assign({}, stateConfig)
     if (_.has(stateConfig, 'Next')) {
@@ -167,7 +155,11 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    newConfig = this.addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
+      let currentCatchConfig = newConfig.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state
@@ -200,7 +192,11 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    newConfig = this.addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
+      let currentCatchConfig = newConfig.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state and set Invoke lambda resource
@@ -238,7 +234,11 @@ class apb {
       Object.assign(helperState, { End: true })
     }
 
-    topLevel = this.addTaskFailureCatchIfNeeded(stateName, topLevel, DecoratorFlags)
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
+      let currentCatchConfig = topLevel.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
 
     let newBranches = []
     Object.assign(Output, topLevel, { Next: helperStateName })

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -146,7 +146,7 @@ class apb {
       let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stepName)]
       newStepConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
     }
-    return stepConfig
+    return newStepConfig
   }
 
   transformTaskState(stateName, stateConfig, States, DecoratorFlags) {

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -138,6 +138,17 @@ class apb {
     }
   }
 
+  addTaskFailureCatchIfNeeded(stepName, stepConfig, DecoratorFlags) {
+    newStepConfig = Object.assign({}, stepConfig)
+
+    if (DecoratorFlags.hasTaskFailureHandler === true && stepName !== this.DecoratorFlags.TaskFailureHandlerName) {
+      let currentCatchConfig = newStepConfig.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stepName)]
+      newStepConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+    }
+    return stepConfig
+  }
+
   transformTaskState(stateName, stateConfig, States, DecoratorFlags) {
 
     let output = {}
@@ -156,11 +167,7 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
-      let currentCatchConfig = newConfig.Catch || []
-      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
-      newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
-    }
+    newConfig = addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state
@@ -193,11 +200,7 @@ class apb {
       Object.assign(newConfig, { "Retry": [RETRY] })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
-      let currentCatchConfig = newConfig.Catch || []
-      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
-      newConfig.Catch = [...currentCatchConfig, ...handlerCatchConfig]
-    }
+    newConfig = addTaskFailureCatchIfNeeded(stateName, stateConfig, DecoratorFlags)
 
     if (this.isStateIntegration(stateName, States)) {
       // Generate helper state and set Invoke lambda resource

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -228,16 +228,21 @@ class apb {
       Type: "Task",
       Resource: "${{self:custom.core.MergeParallelOutput}}"
     }
+
+    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
+      // add catch for top level
+      let currentCatchConfig = topLevel.Catch || []
+      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
+      topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
+
+      // add catch and retries for merge output task
+      helperState.Catch = [this.genTaskFailureHandlerCatchConfig(helperStateName)]
+    }
+
     if (End === undefined) {
       Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States) })
     } else {
       Object.assign(helperState, { End: true })
-    }
-
-    if (DecoratorFlags.hasTaskFailureHandler === true && stateName !== this.DecoratorFlags.TaskFailureHandlerName) {
-      let currentCatchConfig = topLevel.Catch || []
-      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
-      topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
     }
 
     let newBranches = []

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -239,6 +239,10 @@ class apb {
       helperState.Catch = [this.genTaskFailureHandlerCatchConfig(helperStateName)]
     }
 
+    if (!this.isDefaultRetryDisabled(stateName)) {
+      Object.assign(helperState, { "Retry": [RETRY] })
+    }
+
     if (End === undefined) {
       Object.assign(helperState, { Next: this.resolveStateName(stateConfig.Next, States) })
     } else {

--- a/lib/apb.js
+++ b/lib/apb.js
@@ -238,11 +238,7 @@ class apb {
       Object.assign(helperState, { End: true })
     }
 
-    if (DecoratorFlags.hasTaskFailureHandler === true) {
-      let currentCatchConfig = topLevel.Catch || []
-      let handlerCatchConfig = [this.genTaskFailureHandlerCatchConfig(stateName)]
-      topLevel.Catch = [...currentCatchConfig, ...handlerCatchConfig]
-    }
+    topLevel = addTaskFailureCatchIfNeeded(stateName, topLevel, DecoratorFlags)
 
     let newBranches = []
     Object.assign(Output, topLevel, { Next: helperStateName })


### PR DESCRIPTION
**Contributing to Twilio**

- closes the infinite loop if you use parallel state as the task failure handler
- enables default retries for merge_parallel_output
- enables taskFailureHandler for merge_parallel_output (and doesn't introduce another infinite loop)

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
