### PR TITLE
Fix issue in ExtendedConfig Feature caused by Serverless Variable Resolution lifecycle

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 var __spreadArray = (this && this.__spreadArray) || function (to, from) {
     for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
         to[j] = from[i];
@@ -12,14 +23,26 @@ var apb_1 = require("./apb");
 var playbook_extended_config_1 = require("./playbook_extended_config");
 var ajv_config_1 = require("./ajv_config");
 var validators_1 = require("./validators");
+var constants_1 = require("./constants");
 var SlsApb = /** @class */ (function () {
     function SlsApb(serverless, options) {
         var _this = this;
         this.sls = serverless;
         this.options = options;
         this.apb_config = this.getApbConfig();
+        this.hooks = {
+            // Compile scheduled events after the constructor
+            // during the package:compileEvents lifecycle event
+            // because by then, serverless variables will be correctly
+            // resolved
+            "package:compileEvents": this.compileScheduledEvents.bind(this),
+        };
+        // add states execution role to custom variables as well so that it
+        // gets resolved
+        this.sls.service.custom._statesExecutionRole = constants_1.STATES_EXECUTION_ROLE_ARN;
         var playbooks = this.sls
             .service.custom.playbooks;
+        this.playbookNameAndExtendedConfig = {};
         if (!playbooks) {
             this.sls.cli.log("Warning: No playbooks listed for deployment. List playbooks under serverless.yml `custom.playbooks` section to deploy them");
         }
@@ -30,14 +53,13 @@ var SlsApb = /** @class */ (function () {
             playbooks.forEach(function (playbook_config) {
                 var _a, _b;
                 // Determine if playbook_config is simple string or has config object
-                var playbook_dir, playbookEventConfigs;
+                var playbook_dir, playbookExtendedConfig;
                 if (typeof playbook_config === "string") {
                     playbook_dir = playbook_config;
-                    playbookEventConfigs = null;
+                    playbookExtendedConfig = null;
                 }
                 else if (Object.prototype.toString.call(playbook_config) === "[object Object]") {
-                    _a = Object.entries(playbook_config)[0], playbook_dir = _a[0], playbookEventConfigs = _a[1];
-                    ajv_config_1.validate(playbookEventConfigs, validators_1.playbookEventsConfigValidator);
+                    _a = Object.entries(playbook_config)[0], playbook_dir = _a[0], playbookExtendedConfig = _a[1];
                 }
                 else {
                     throw new Error("Invalid configuration in playbooks object. Only string or object allowed. Given " + playbook_config);
@@ -59,9 +81,8 @@ var SlsApb = /** @class */ (function () {
                     else {
                         _this.sls.service.resources.push(temp, renderedPlaybook.StateMachineYaml);
                     }
-                    // If there's a playbookEventConfigs, build it and add it to the resources
-                    if (!!playbookEventConfigs) {
-                        _this.sls.service.resources.push(playbook_extended_config_1.buildScheduleResourcesFromEventConfigs(renderedPlaybook.PlaybookName, playbookEventConfigs.events));
+                    if (!!playbookExtendedConfig) {
+                        _this.playbookNameAndExtendedConfig[renderedPlaybook.PlaybookName] = playbookExtendedConfig;
                     }
                     // Add the rendered State Machine and the stored resource to the resources list
                     //this.sls.cli.log(JSON.stringify(this.sls.service.resources, null, 2));
@@ -83,6 +104,15 @@ var SlsApb = /** @class */ (function () {
     SlsApb.prototype.buildPlaybookPath = function (playbookDir) {
         var playbooksFolder = this.apb_config.playbooksFolder || "./playbooks";
         return playbooksFolder + "/" + playbookDir + "/playbook.json";
+    };
+    SlsApb.prototype.compileScheduledEvents = function () {
+        var compiledResource;
+        for (var _i = 0, _a = Object.entries(this.playbookNameAndExtendedConfig); _i < _a.length; _i++) {
+            var _b = _a[_i], playbookName = _b[0], extendedConfig = _b[1];
+            ajv_config_1.validate(extendedConfig, validators_1.playbookEventsConfigValidator);
+            compiledResource = playbook_extended_config_1.buildScheduleResourcesFromEventConfigs(playbookName, extendedConfig.events, this.sls.service.custom._statesExecutionRole);
+            this.sls.service.resources.Resources = __assign(__assign({}, this.sls.service.resources.Resources), compiledResource.Resources);
+        }
     };
     return SlsApb;
 }());

--- a/dist/index.js
+++ b/dist/index.js
@@ -112,6 +112,7 @@ var SlsApb = /** @class */ (function () {
             ajv_config_1.validate(extendedConfig, validators_1.playbookEventsConfigValidator);
             compiledResource = playbook_extended_config_1.buildScheduleResourcesFromEventConfigs(playbookName, extendedConfig.events, this.sls.service.custom._statesExecutionRole);
             this.sls.service.resources.Resources = __assign(__assign({}, this.sls.service.resources.Resources), compiledResource.Resources);
+            this.sls.service.resources.Outputs = __assign(__assign({}, this.sls.service.resources.Outputs), compiledResource.Outputs);
         }
     };
     return SlsApb;

--- a/dist/playbook_extended_config.js
+++ b/dist/playbook_extended_config.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.buildScheduleResourceName = exports.buildScheduleResourcesFromEventConfigs = exports.buildScheduleResource = exports.buildScheduleResourceProperties = exports.buildScheduleResourceTarget = exports.ScheduleResourceState = void 0;
+exports.buildScheduleResourceName = exports.buildScheduleResourcesFromEventConfigs = exports.buildScheduleResourceOutput = exports.buildScheduleResource = exports.buildScheduleResourceProperties = exports.buildScheduleResourceTarget = exports.ScheduleResourceState = void 0;
 var constants_1 = require("./constants");
 var errors_1 = require("./errors");
 var ScheduleResourceState;
@@ -47,15 +47,26 @@ function buildScheduleResource(playbookName, scheduleConfig) {
     };
 }
 exports.buildScheduleResource = buildScheduleResource;
+function buildScheduleResourceOutput(scheduleResourceName, scheduleConfig) {
+    return {
+        Description: scheduleConfig.description,
+        Value: {
+            Ref: scheduleResourceName,
+        },
+    };
+}
+exports.buildScheduleResourceOutput = buildScheduleResourceOutput;
 function buildScheduleResourcesFromEventConfigs(playbookName, scheduleConfigs, roleArn) {
     var resources = {};
+    var outputs = {};
     scheduleConfigs.forEach(function (config, index) {
         var resourceName = buildScheduleResourceName(playbookName, index);
         var resource = buildScheduleResource(playbookName, config.schedule);
         resource.Properties.Targets[0].RoleArn = roleArn;
         resources[resourceName] = resource;
+        outputs[resourceName] = buildScheduleResourceOutput(resourceName, config.schedule);
     });
-    return { Resources: resources };
+    return { Resources: resources, Outputs: outputs };
 }
 exports.buildScheduleResourcesFromEventConfigs = buildScheduleResourcesFromEventConfigs;
 function buildScheduleResourceName(playbookName, sequenceId) {

--- a/dist/playbook_extended_config.js
+++ b/dist/playbook_extended_config.js
@@ -47,11 +47,13 @@ function buildScheduleResource(playbookName, scheduleConfig) {
     };
 }
 exports.buildScheduleResource = buildScheduleResource;
-function buildScheduleResourcesFromEventConfigs(playbookName, scheduleConfigs) {
+function buildScheduleResourcesFromEventConfigs(playbookName, scheduleConfigs, roleArn) {
     var resources = {};
     scheduleConfigs.forEach(function (config, index) {
         var resourceName = buildScheduleResourceName(playbookName, index);
-        resources[resourceName] = buildScheduleResource(playbookName, config.schedule);
+        var resource = buildScheduleResource(playbookName, config.schedule);
+        resource.Properties.Targets[0].RoleArn = roleArn;
+        resources[resourceName] = resource;
     });
     return { Resources: resources };
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -143,6 +143,10 @@ class SlsApb {
         ...this.sls.service.resources.Resources,
         ...compiledResource.Resources,
       };
+      this.sls.service.resources.Outputs = {
+        ...this.sls.service.resources.Outputs,
+        ...compiledResource.Outputs,
+      };
     }
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,19 +9,35 @@ import {
 } from "./playbook_extended_config";
 import { validate } from "./ajv_config";
 import { playbookEventsConfigValidator } from "./validators";
+import { STATES_EXECUTION_ROLE_ARN } from "./constants";
 
 class SlsApb {
   sls: any;
   options: any;
   apb_config: ApbConfig;
+  hooks: object;
+  playbookNameAndExtendedConfig: Record<string, PlaybookEventsConfig>;
 
   constructor(serverless, options) {
     this.sls = serverless;
     this.options = options;
     this.apb_config = this.getApbConfig();
 
+    this.hooks = {
+      // Compile scheduled events after the constructor
+      // during the package:compileEvents lifecycle event
+      // because by then, serverless variables will be correctly
+      // resolved
+      "package:compileEvents": this.compileScheduledEvents.bind(this),
+    };
+    // add states execution role to custom variables as well so that it
+    // gets resolved
+    this.sls.service.custom._statesExecutionRole = STATES_EXECUTION_ROLE_ARN;
+
     let playbooks: (string | Record<string, PlaybookEventsConfig>)[] = this.sls
       .service.custom.playbooks;
+
+    this.playbookNameAndExtendedConfig = {};
 
     if (!playbooks) {
       this.sls.cli.log(
@@ -34,19 +50,17 @@ class SlsApb {
 
       playbooks.forEach((playbook_config) => {
         // Determine if playbook_config is simple string or has config object
-        let playbook_dir, playbookEventConfigs;
+        let playbook_dir, playbookExtendedConfig;
 
         if (typeof playbook_config === "string") {
           playbook_dir = playbook_config;
-          playbookEventConfigs = null;
+          playbookExtendedConfig = null;
         } else if (
           Object.prototype.toString.call(playbook_config) === "[object Object]"
         ) {
-          [playbook_dir, playbookEventConfigs] = Object.entries(
+          [playbook_dir, playbookExtendedConfig] = Object.entries(
             playbook_config
           )[0];
-
-          validate(playbookEventConfigs, playbookEventsConfigValidator);
         } else {
           throw new Error(
             `Invalid configuration in playbooks object. Only string or object allowed. Given ${playbook_config}`
@@ -78,14 +92,10 @@ class SlsApb {
             );
           }
 
-          // If there's a playbookEventConfigs, build it and add it to the resources
-          if (!!playbookEventConfigs) {
-            this.sls.service.resources.push(
-              buildScheduleResourcesFromEventConfigs(
-                renderedPlaybook.PlaybookName,
-                playbookEventConfigs.events
-              )
-            );
+          if (!!playbookExtendedConfig) {
+            this.playbookNameAndExtendedConfig[
+              renderedPlaybook.PlaybookName
+            ] = playbookExtendedConfig;
           }
 
           // Add the rendered State Machine and the stored resource to the resources list
@@ -114,6 +124,26 @@ class SlsApb {
   buildPlaybookPath(playbookDir): string {
     const playbooksFolder = this.apb_config.playbooksFolder || "./playbooks";
     return `${playbooksFolder}/${playbookDir}/playbook.json`;
+  }
+
+  compileScheduledEvents() {
+    let compiledResource;
+    for (const [playbookName, extendedConfig] of Object.entries(
+      this.playbookNameAndExtendedConfig
+    )) {
+      validate(extendedConfig, playbookEventsConfigValidator);
+
+      compiledResource = buildScheduleResourcesFromEventConfigs(
+        playbookName,
+        extendedConfig.events,
+        this.sls.service.custom._statesExecutionRole
+      );
+
+      this.sls.service.resources.Resources = {
+        ...this.sls.service.resources.Resources,
+        ...compiledResource.Resources,
+      };
+    }
   }
 }
 

--- a/lib/playbook_extended_config.ts
+++ b/lib/playbook_extended_config.ts
@@ -47,7 +47,7 @@ export enum ScheduleResourceState {
 export interface ScheduleResourceTarget {
   Arn: object;
   Id: string;
-  RoleArn: typeof STATES_EXECUTION_ROLE_ARN;
+  RoleArn: string;
   Input?: string;
 }
 
@@ -103,15 +103,15 @@ export function buildScheduleResource(
 
 export function buildScheduleResourcesFromEventConfigs(
   playbookName: string,
-  scheduleConfigs: PlaybookSchedule[]
+  scheduleConfigs: PlaybookSchedule[],
+  roleArn: string
 ) {
   const resources = {};
   scheduleConfigs.forEach((config, index) => {
     const resourceName = buildScheduleResourceName(playbookName, index);
-    resources[resourceName] = buildScheduleResource(
-      playbookName,
-      config.schedule
-    );
+    const resource = buildScheduleResource(playbookName, config.schedule);
+    resource.Properties.Targets[0].RoleArn = roleArn;
+    resources[resourceName] = resource;
   });
 
   return { Resources: resources };

--- a/lib/playbook_extended_config.ts
+++ b/lib/playbook_extended_config.ts
@@ -51,6 +51,11 @@ export interface ScheduleResourceTarget {
   Input?: string;
 }
 
+export interface ScheduleResourceOutput {
+  Description: string;
+  Value: object;
+}
+
 export function buildScheduleResourceTarget(
   playbookName: string,
   input: string | undefined
@@ -101,20 +106,37 @@ export function buildScheduleResource(
   };
 }
 
+export function buildScheduleResourceOutput(
+  scheduleResourceName: string,
+  scheduleConfig: PlaybookScheduleConfig
+): ScheduleResourceOutput {
+  return {
+    Description: scheduleConfig.description,
+    Value: {
+      Ref: scheduleResourceName,
+    },
+  };
+}
+
 export function buildScheduleResourcesFromEventConfigs(
   playbookName: string,
   scheduleConfigs: PlaybookSchedule[],
   roleArn: string
 ) {
   const resources = {};
+  const outputs = {};
   scheduleConfigs.forEach((config, index) => {
     const resourceName = buildScheduleResourceName(playbookName, index);
     const resource = buildScheduleResource(playbookName, config.schedule);
     resource.Properties.Targets[0].RoleArn = roleArn;
     resources[resourceName] = resource;
+    outputs[resourceName] = buildScheduleResourceOutput(
+      resourceName,
+      config.schedule
+    );
   });
 
-  return { Resources: resources };
+  return { Resources: resources, Outputs: outputs };
 }
 
 export function buildScheduleResourceName(

--- a/test/test_playbook_extended_config.js
+++ b/test/test_playbook_extended_config.js
@@ -13,6 +13,8 @@ const {
 const testPlaybookName = "TestPlaybook";
 const testInput = '{ "hello": "world" }';
 const testDescription = "Hello world";
+const testEventRuleResource0 = `${testPlaybookName}EventRule0`;
+const testEventRuleResource1 = `${testPlaybookName}EventRule1`;
 
 const testScheduleConfigNoInput = {
   rate: "rate(1 minute)",
@@ -68,10 +70,28 @@ const testPlaybookEventConfigs = [
   { schedule: testScheduleConfigNoInput },
 ];
 
+const expectedScheduleResourceOutput0 = {
+  Description: testScheduleConfigNoInput.description,
+  Value: {
+    Ref: testEventRuleResource0,
+  },
+};
+
+const expectedScheduleResourceOutput1 = {
+  Description: testScheduleConfigNoInput.description,
+  Value: {
+    Ref: testEventRuleResource1,
+  },
+};
+
 const expectedScheduleResourcesFromEventConfig = {
   Resources: {
-    [`${testPlaybookName}EventRule0`]: expectedScheduleResourceWithInput,
-    [`${testPlaybookName}EventRule1`]: expectedScheduleResourceNoInput,
+    [testEventRuleResource0]: expectedScheduleResourceWithInput,
+    [testEventRuleResource1]: expectedScheduleResourceNoInput,
+  },
+  Outputs: {
+    [testEventRuleResource0]: expectedScheduleResourceOutput0,
+    [testEventRuleResource1]: expectedScheduleResourceOutput1,
   },
 };
 

--- a/test/test_playbook_extended_config.js
+++ b/test/test_playbook_extended_config.js
@@ -134,7 +134,8 @@ describe("playbook_events", () => {
     it("Should return expected Resources mapped to their Names", () => {
       const builtResourceMap = buildScheduleResourcesFromEventConfigs(
         testPlaybookName,
-        testPlaybookEventConfigs
+        testPlaybookEventConfigs,
+        STATES_EXECUTION_ROLE_ARN
       );
 
       assert.deepStrictEqual(

--- a/test/test_slsApb.js
+++ b/test/test_slsApb.js
@@ -5,5 +5,6 @@ const { minimalSlsObjWithOneScheduledPlaybook } = require("./mocks");
 describe("#SlsApb", () => {
   it("Should instantiate new SlsApb object and render appropriate Resources without raising an error", () => {
     const slsApb = new SlsApb(minimalSlsObjWithOneScheduledPlaybook, {});
+    slsApb.compileScheduledEvents();
   });
 });


### PR DESCRIPTION
This PR fixes the behavior of the playbook schedule generator by attaching the event to a lifecycle hook instead of executing it inside the contructor for SlsAPB

The problematic behavior in question is that this config **works**
```
custom:
  playbooks:
    - example_scheduled_playbook:
        events:
          - schedule:
              rate: "cron(0 12 * * ? *)"
              description: "Sample playbook schedule"
              enabled: true <---- boleaan
              input: '{"json": "payload"}'
```

But this config **fails**

```
custom:
  scheduleEnabled:
    sandbox: false
    dev: false
    stage: false
    prod: true
  playbooks:
    - example_scheduled_playbook:
        events:
          - schedule:
              rate: "cron(0 12 * * ? *)"
              description: "Sample playbook schedule"
              enabled: ${{self:custom.scheduleEnabled.${{self:provider.stage}}}} <-------- string that will resolve to bolean
              input: '{"json": "payload"}'
```


The root cause here is that inside the constructor for SlsAPB (where most of slsAPB code runs), variables have not been resolved yet. however the ExtendedConfig validator needs variables to be fully resolved in order to properly validate the users configuration and generate the appropriate resources. Simply changing the validator to expect bolean or string doesn't address the problem as it becomes impossible to validate if the string will actually resolve to a valid input when serverless resolves variables and will lead to incorrect generation of resources.


This PR tackles the issue by moving schedule resource generation outside the constructor and onto the 'package:compileEvents' event which is the same event that serverless framework hooks into for compiling scheduled events on functions. By the time that lifecycle event executes, variables are correctly resolved.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
